### PR TITLE
Fix missing concurrency group

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -113,6 +113,7 @@ steps:
  
   - label: ":large_green_square: OPEN GATE: Approve Deployment"
     key: "start-approval"
+    concurrency_group: "approve-deployment"
     depends_on: ["wait-end-integration-tests"]
     command: echo "Opening Approve Deployment gate"
 
@@ -123,11 +124,13 @@ steps:
 
   - label: "Approve Deployment"
     key: "approval"
+    concurrency_group: "approve-deployment"
     depends_on: ["wait-start-approval"]
     command: echo "approve-deployment.sh"
 
   - label: ":large_red_square: CLOSE GATE: Approve Deployment"
     key: "end-approval"
+    concurrency_group: "approve-deployment"
     command: echo "Closed Approve Deployment gate"
 
   - wait


### PR DESCRIPTION
The `approval` steps don't currently use a `concurrency_group` but refer to one in the docs.

- [x] Add a `concurrency_group` to the `approval` steps in the `release` job.
